### PR TITLE
fix file not found

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ DIR="${WORKSPACE_DIR}${1}"
 
 for FILE_EXT in '*.js' '*.css' '*.html'
 do
-	FILES=`find $DIR -type f -path $FILE_EXT`
+	FILES=`find $DIR -type f -path "$FILE_EXT"`
 	if [ -z "$FILES" ]
 	then
 		echo "no $FILE_EXT files found"


### PR DESCRIPTION
When the current directory contains any of js, css, or html file, it fails to find files in the target directory because * is replaced to concrete file names.